### PR TITLE
Added optional export of already opened PIL image

### DIFF
--- a/colorgram/colorgram.py
+++ b/colorgram/colorgram.py
@@ -35,7 +35,10 @@ class Color(object):
             return self._hsl
 
 def extract(f, number_of_colors):
-    image = Image.open(f)
+    if str(type(f)) == "<class 'PIL.JpegImagePlugin.JpegImageFile'>":
+        image = f
+    else:
+        image = Image.open(f)
     if image.mode not in ('RGB', 'RGBA', 'RGBa'):
         image = image.convert('RGB')
     


### PR DESCRIPTION
I was using this module in other project where a open image with PIL, and resize it. To use this module as is I've had to save resized file to extract colors, and delete afterwards. With this small change this snippet is executed just fine
```
import colorgram
from PIL import Image
#this one is working fine
f = '2.jpg'
a = colorgram.extract(f, 2)

# this one fails
b = Image.open(f)
b.thumbnail((360, 360), Image.ANTIALIAS)
c = colorgram.extract(b, 2)
```

The check for the PIL image class is ugly, but to use isinstance(im, JpegImagePlugin.JpegImageFile) we need to import JpegImagePlugin from PIL, and isinstance(im, object) returns true for strings as well