### PR TITLE
add support for getting image data directly from a url

### DIFF
--- a/colorgram/colorgram.py
+++ b/colorgram/colorgram.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import array
+import requests
 from collections import namedtuple
 from PIL import Image
+from io import BytesIO
 
 import sys
 if sys.version_info[0] <= 2:
@@ -34,8 +36,13 @@ class Color(object):
             self._hsl = Hsl(*hsl(*self.rgb))
             return self._hsl
 
-def extract(f, number_of_colors):
-    image = f if isinstance(f, Image.Image) else Image.open(f)
+def extract(f, number_of_colors, url=False):
+    if url:
+        img= requests.get(f)
+        image = Image.open(BytesIO(img.content))
+    else:
+        image = f if isinstance(f, Image.Image) else Image.open(f)
+
     if image.mode not in ('RGB', 'RGBA', 'RGBa'):
         image = image.convert('RGB')
     

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,10 @@ def test_extract_from_image_object():
     image = Image.open('data/test.png')
     colorgram.extract(image, 1)
 
+def test_extract_from_url():
+    url = 'https://camo.githubusercontent.com/ca5e835b6671e2eb15679c13af834927f3d4d26e/687474703a2f2f692e696d6775722e636f6d2f4265526561524d2e706e67'
+    colorgram.extract(url,url=True)
+
 def test_color_access():
     color = colorgram.Color(255, 151, 210, 0.15)
 


### PR DESCRIPTION
I wanted to use this library to do some cool stuff with my hue lights, but I needed to get a color palette from a url - so I had to modify the local installation. I thought I'd make a pull request to implement this since it was such a simple fix. I think being able to get a palette from a url is a very useful feature.