### PR TITLE
Add support for images stored in memory (Images downloaded from a url)

### DIFF
--- a/colorgram/colorgram.py
+++ b/colorgram/colorgram.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import array
-import requests
 from collections import namedtuple
 from PIL import Image
 from io import BytesIO
@@ -36,10 +35,15 @@ class Color(object):
             self._hsl = Hsl(*hsl(*self.rgb))
             return self._hsl
 
-def extract(f, number_of_colors, url=False):
-    if url:
-        img= requests.get(f)
-        image = Image.open(BytesIO(img.content))
+def from_url(data):
+    if isinstance(data, (bytes, bytearray)):
+        return True
+    else:
+        return False
+
+def extract(f, number_of_colors):
+    if from_url(f):
+        image = Image.open(BytesIO(f))
     else:
         image = f if isinstance(f, Image.Image) else Image.open(f)
 

--- a/colorgram/colorgram.py
+++ b/colorgram/colorgram.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import array
+import requests
 from collections import namedtuple
 from PIL import Image
+from io import BytesIO
 
 import sys
 if sys.version_info[0] <= 2:
@@ -34,8 +36,13 @@ class Color(object):
             self._hsl = Hsl(*hsl(*self.rgb))
             return self._hsl
 
-def extract(f, number_of_colors):
-    image = f if isinstance(f, Image.Image) else Image.open(f)
+def extract(f, number_of_colors, url=False):
+    if url:
+        img= requests.get(f)
+        image = Image.open(BytesIO(img.content))
+    else:
+        image = f if isinstance(f, Image.Image) else Image.open(f)
+
     if image.mode not in ('RGB', 'RGBA', 'RGBa'):
         image = image.convert('RGB')
     

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from colorgram import colorgram
+import colorgram
 from PIL import Image
 import requests
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 
-import colorgram
+from colorgram import colorgram
 from PIL import Image
+import requests
 
 def test_extract_from_file():
     colorgram.extract('data/test.png', 1)
 
 def test_extract_from_image_object():
     image = Image.open('data/test.png')
-    colorgram.extract(image, 1)
+    colors = colorgram.extract(image, 1)
 
 def test_extract_from_url():
     url = 'https://camo.githubusercontent.com/ca5e835b6671e2eb15679c13af834927f3d4d26e/687474703a2f2f692e696d6775722e636f6d2f4265526561524d2e706e67'
-    colorgram.extract(url,url=True)
+    res = requests.get(url)
+    colorgram.extract(res.content, 1)
 
 def test_color_access():
     color = colorgram.Color(255, 151, 210, 0.15)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,10 @@ def test_extract_from_image_object():
     image = Image.open('data/test.png')
     colorgram.extract(image, 1)
 
+def test_extract_from_url():
+    url = 'https://camo.githubusercontent.com/ca5e835b6671e2eb15679c13af834927f3d4d26e/687474703a2f2f692e696d6775722e636f6d2f4265526561524d2e706e67'
+    colorgram.extract(url,url=True)
+
 def test_color_access():
     color = colorgram.Color(255, 151, 210, 0.15)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ def test_extract_from_file():
 
 def test_extract_from_image_object():
     image = Image.open('data/test.png')
-    colors = colorgram.extract(image, 1)
+    colorgram.extract(image, 1)
 
 def test_extract_from_url():
     url = 'https://camo.githubusercontent.com/ca5e835b6671e2eb15679c13af834927f3d4d26e/687474703a2f2f692e696d6775722e636f6d2f4265526561524d2e706e67'


### PR DESCRIPTION
I understand the concern from earlier where Colorgram was responsible for downloading the image, this time I made it so that one can downloaded the image with requests and pass the data in memory to colorgram which detects data type and opens the image accordingly.