### PR TITLE
support for binary data color extraction (extract from downloaded image)

### DIFF
--- a/colorgram/colorgram.py
+++ b/colorgram/colorgram.py
@@ -6,6 +6,7 @@ from __future__ import division
 import array
 from collections import namedtuple
 from PIL import Image
+from io import BytesIO
 
 import sys
 if sys.version_info[0] <= 2:
@@ -34,8 +35,18 @@ class Color(object):
             self._hsl = Hsl(*hsl(*self.rgb))
             return self._hsl
 
+def is_bytes(data):
+    if isinstance(data, (bytes, bytearray)):
+        return True
+    else:
+        return False
+
 def extract(f, number_of_colors):
-    image = f if isinstance(f, Image.Image) else Image.open(f)
+    if is_bytes(f):
+        image = Image.open(BytesIO(f))
+    else:
+        image = f if isinstance(f, Image.Image) else Image.open(f)
+
     if image.mode not in ('RGB', 'RGBA', 'RGBa'):
         image = image.convert('RGB')
     

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,11 @@ def test_extract_from_image_object():
     image = Image.open('data/test.png')
     colorgram.extract(image, 1)
 
+def test_extract_from_bytes():
+    with open('data/test.png','rb') as img:
+        img_data = img.read()
+        colorgram.extract(img_data, 1)
+
 def test_color_access():
     color = colorgram.Color(255, 151, 210, 0.15)
 


### PR DESCRIPTION
Same motivation and concept as before, with following changes:
- Removed references to URL - abstracted to refer only to binary data,
- squashed to one commit
- changed `test_api.py` to test binary data with locally downloaded image rather than one downloaded during testing