### PR TITLE
feat: adds traditional hsl as a prop for use

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -61,6 +61,7 @@ A color extracted from an image. Its properties are:
 
 * ``Color.rgb`` - The color represented as a ``namedtuple`` of RGB from 0 to 255, e.g. ``(r=255, g=151, b=210)``.
 * ``Color.hsl`` - The color represented as a ``namedtuple`` of HSL from 0 to 255, e.g. ``(h=230, s=255, l=203)``.
+* ``Color.traditional_hsl`` - The color represented as a ``namedtuple`` in traditional HSL from 0 to 360 for hue and 0 to 100 for saturation and lightnes, e.g. ``(h=324, s=100, l=79)``.
 * ``Color.proportion`` - The proportion of the image that is in the extracted color from 0 to 1, e.g. ``0.34``.
 
 Sorting by HSL


### PR DESCRIPTION
Issue #6 points out a major issue that the HSL is not returned in the standard format (360, 100, 100). It seems like HSLs logic should just be replaced but in case the 255 version is used somewhere that I just don't know about, this branch adds `traditional_hsl` as a prop that can used to get the HSL in the form most people expect it to be